### PR TITLE
Add homepage property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "website-react",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://waterloo-rocketry.github.io/website-react",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^11.2.7",


### PR DESCRIPTION
The `homepage` property in `package.json` is required for  the application to deploy correctly.

For now, I'm leaving the URL as the default (https://waterloo-rocketry.github.io/website-react), not with our nice custom domain. Once we're in a more finished state, we can easily switch over

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/6)
<!-- Reviewable:end -->
