### PR TITLE
Fix website routing issue with GitHub Pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,28 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
     <title>React App</title>
   </head>
   <body>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -3,6 +3,8 @@ import {
   Navbar, Container, Nav, Image,
 } from 'react-bootstrap';
 
+import { Link } from 'react-router-dom';
+
 import styles from './Navigation.module.css';
 
 import bannerLogoImage from '../img/banner_logo.png';
@@ -12,7 +14,7 @@ const Navigation = () => {
   return (
     <Navbar collapseOnSelect expand="lg" variant="dark" fixed="top" className={styles.navbar}>
       <Container className={styles.navbarContainer} fluid>
-        <Navbar.Brand href="/">
+        <Navbar.Brand as={Link} to="/">
           <Image
             src={bannerLogoImage}
             alt="Waterloo Rocketry Logo"
@@ -22,31 +24,31 @@ const Navigation = () => {
         <Navbar.Toggle />
         <Navbar.Collapse>
           <Nav className={`${styles.nav} justify-content-end`}>
-            <Nav.Link className={styles.navbarLink} href="join">
+            <Nav.Link as={Link} className={styles.navbarLink} to="join">
               JOIN
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="competition">
+            <Nav.Link as={Link} className={styles.navbarLink} to="competition">
               COMPETITION
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="sponsors">
+            <Nav.Link as={Link} className={styles.navbarLink} to="sponsors">
               SPONSORS
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="rockets">
+            <Nav.Link as={Link} className={styles.navbarLink} to="rockets">
               ROCKETS
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="subsystems">
+            <Nav.Link as={Link} className={styles.navbarLink} to="subsystems">
               SUBSYSTEMS
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="team">
+            <Nav.Link as={Link} className={styles.navbarLink} to="team">
               TEAM
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="awards">
+            <Nav.Link as={Link} className={styles.navbarLink} to="awards">
               AWARDS
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="outreach">
+            <Nav.Link as={Link} className={styles.navbarLink} to="outreach">
               OUTREACH
             </Nav.Link>
-            <Nav.Link className={styles.navbarLink} href="contact">
+            <Nav.Link as={Link} className={styles.navbarLink} to="contact">
               CONTACT
             </Nav.Link>
           </Nav>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -3,8 +3,6 @@ import {
   Navbar, Container, Nav, Image,
 } from 'react-bootstrap';
 
-import { Link } from 'react-router-dom';
-
 import styles from './Navigation.module.css';
 
 import bannerLogoImage from '../img/banner_logo.png';
@@ -14,7 +12,7 @@ const Navigation = () => {
   return (
     <Navbar collapseOnSelect expand="lg" variant="dark" fixed="top" className={styles.navbar}>
       <Container className={styles.navbarContainer} fluid>
-        <Navbar.Brand as={Link} to="/">
+        <Navbar.Brand href="/">
           <Image
             src={bannerLogoImage}
             alt="Waterloo Rocketry Logo"
@@ -24,31 +22,31 @@ const Navigation = () => {
         <Navbar.Toggle />
         <Navbar.Collapse>
           <Nav className={`${styles.nav} justify-content-end`}>
-            <Nav.Link as={Link} className={styles.navbarLink} to="join">
+            <Nav.Link className={styles.navbarLink} href="join">
               JOIN
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="competition">
+            <Nav.Link className={styles.navbarLink} href="competition">
               COMPETITION
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="sponsors">
+            <Nav.Link className={styles.navbarLink} href="sponsors">
               SPONSORS
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="rockets">
+            <Nav.Link className={styles.navbarLink} href="rockets">
               ROCKETS
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="subsystems">
+            <Nav.Link className={styles.navbarLink} href="subsystems">
               SUBSYSTEMS
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="team">
+            <Nav.Link className={styles.navbarLink} href="team">
               TEAM
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="awards">
+            <Nav.Link className={styles.navbarLink} href="awards">
               AWARDS
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="outreach">
+            <Nav.Link className={styles.navbarLink} href="outreach">
               OUTREACH
             </Nav.Link>
-            <Nav.Link as={Link} className={styles.navbarLink} to="contact">
+            <Nav.Link className={styles.navbarLink} href="contact">
               CONTACT
             </Nav.Link>
           </Nav>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {
-  Route, BrowserRouter, Routes as Switch,
+  Route, HashRouter, Routes as Switch,
 } from 'react-router-dom';
 
 import Navigation from './components/Navigation';
@@ -13,16 +13,19 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 
 ReactDOM.render(
-  <BrowserRouter>
-    <Navigation />
-    <Switch>
-      <Route
-        path="/"
-        element={<Page title="Home"><Home /></Page>}
-      />
-    </Switch>
-    <Footer />
-  </BrowserRouter>,
+  <React.StrictMode>
+    <HashRouter>
+      <Navigation />
+      <Switch>
+        <Route
+          exact
+          path="/"
+          element={<Page title="Home"><Home /></Page>}
+        />
+      </Switch>
+      <Footer />
+    </HashRouter>
+  </React.StrictMode>,
 
   document.getElementById('root'),
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {
-  Route, HashRouter, Routes as Switch,
+  Route, BrowserRouter, Routes,
 } from 'react-router-dom';
 
 import Navigation from './components/Navigation';
@@ -14,17 +14,17 @@ import './index.css';
 
 ReactDOM.render(
   <React.StrictMode>
-    <HashRouter>
+    <BrowserRouter basename="/website-react">
       <Navigation />
-      <Switch>
+      <Routes>
         <Route
           exact
           path="/"
           element={<Page title="Home"><Home /></Page>}
         />
-      </Switch>
+      </Routes>
       <Footer />
-    </HashRouter>
+    </BrowserRouter>
   </React.StrictMode>,
 
   document.getElementById('root'),


### PR DESCRIPTION
It turns out that GitHub pages doesn't support routers that use the history API, such as the React Router that we're using - [see here](https://create-react-app.dev/docs/deployment/#github-pages-https-pagesgithubcom). I found a workaround that tricks GitHub Pages into working using redirects (https://github.com/rafgraph/spa-github-pages) and I have implemented it. It works well.

In addition, the bootstrap `Nav.Link` components that are used for the navbar are not compatible with React Router [see here](https://stackoverflow.com/questions/54843302/reactjs-bootstrap-navbar-and-routing-not-working-together). Fortunately, you can override what component the bootstrap component is rendering, which makes it work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/7)
<!-- Reviewable:end -->
