### PR TITLE
Remove mentions of /website-react basenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "website-react",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://waterloo-rocketry.github.io/website-react",
+  "homepage": "https://waterloorocketry.com",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^11.2.7",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -37,7 +37,7 @@ import './index.css';
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter basename="/website-react">
+    <BrowserRouter>
       <Navigation />
       <Routes>
         <Route

--- a/src/routes/Rockets.jsx
+++ b/src/routes/Rockets.jsx
@@ -20,7 +20,7 @@ const Rockets = () => {
         <Row xl={3} md={2} sm={1}>
           <Col>
             <RocketCard
-              url="/website-react/rockets/kots"
+              url="/rockets/kots"
               title="KRAKEN OF THE SKY"
               date="2021-2022"
               image={rocketKrakenOfTheSky}
@@ -29,7 +29,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/sots"
+              url="/rockets/sots"
               title="SHARK OF THE SKY"
               date="2019"
               image={rocketSharkOfTheSky}
@@ -38,7 +38,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/uxo"
+              url="/rockets/uxo"
               title="UNEXPLODED ORDNANCE"
               date="2018"
               image={rocketUnexplodedOrdnance}
@@ -47,7 +47,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/vidar3"
+              url="/rockets/vidar3"
               title="VIDAR III"
               date="2016/2017"
               image={rocketVidar3}
@@ -56,7 +56,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/vidar2"
+              url="/rockets/vidar2"
               title="VIDAR II"
               date="2015"
               image={rocketVidar2}
@@ -65,7 +65,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/vidar"
+              url="/rockets/vidar"
               title="VIDAR"
               date="2014"
               image={rocketVidar}
@@ -74,7 +74,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/silverbrant"
+              url="/rockets/silverbrant"
               title="SILVER BRANT"
               date="2013"
               image={rocketSilverBrant}
@@ -83,7 +83,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/eridani"
+              url="/rockets/eridani"
               title="ERIDANI"
               date="2012"
               image={rocketEridani}
@@ -92,7 +92,7 @@ const Rockets = () => {
           </Col>
           <Col>
             <RocketCard
-              url="/website-react/rockets/wrt1"
+              url="/rockets/wrt1"
               title="WRT 1"
               date="2011"
               image={rocketWRT1}


### PR DESCRIPTION
What it says on the tin. In theory, this should make this repo a drop-in replacement for the old website.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/27)
<!-- Reviewable:end -->
