### PR TITLE
Create CNAME in public folder

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.waterloorocketry.com


### PR DESCRIPTION
As per https://github.com/tschaub/gh-pages/issues/213#issuecomment-478248804, created the CNAME file that GitHub Pages uses for the custom domain into the `public` folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/35)
<!-- Reviewable:end -->
