### PR TITLE
fixed scrolling to the top reset issue

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -5,7 +5,7 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, behavior: 'instant' });
   }, [pathname]);
 
   return null;

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,6 @@
 
 html, body {
 	height: 100%;
-	/* overflow: auto; */
 }
 
 body {

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 
 html, body {
 	height: 100%;
-	overflow: auto;
+	/* overflow: auto; */
 }
 
 body {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,6 +32,7 @@ import Vidar from './routes/rocketPages/Vidar';
 import SilverBrant from './routes/rocketPages/SilverBrant';
 import Eridani from './routes/rocketPages/Eridani';
 import WRT1 from './routes/rocketPages/WRT1';
+import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
@@ -39,6 +40,7 @@ import './index.css';
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
+      <ScrollToTop />
       <Navigation />
       <Routes>
         <Route


### PR DESCRIPTION
Added a Scroll-to-top reset function and integrated it into the index.jsx. Commented out the "overflow: auto" in the index.css but did not affect the overall appearance of the interface. Now each time when you switch to a new page, the scrolling should automatically go to the top of the page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/42)
<!-- Reviewable:end -->
