### PR TITLE
Add missing link to sponsor package

### DIFF
--- a/src/routes/Sponsors.jsx
+++ b/src/routes/Sponsors.jsx
@@ -89,8 +89,14 @@ const Sponsors = () => {
             <Content title="WANT TO BECOME A SPONSOR?">
               <p>
                 If you would like to contact us about sponsorship opportunities, check out our
-                sponsorship package here and please email us at
-                <a href="mailto:contact@waterloorocketry.com"> contact@waterloorocketry.com.</a>
+                sponsorship package
+                {' '}
+                <a href="sponsorship">here</a>
+                {' '}
+                and please email us at
+                {' '}
+                <a href="mailto:contact@waterloorocketry.com">contact@waterloorocketry.com</a>
+                .
               </p>
             </Content>
           </Col>


### PR DESCRIPTION
I was procrastinating and noticed that there was a missing link to the sponsorship package on the sponsors page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/51)
<!-- Reviewable:end -->
