### PR TITLE
KotS Page Typo

### DIFF
--- a/src/routes/rocketPages/KrakenOfTheSky.jsx
+++ b/src/routes/rocketPages/KrakenOfTheSky.jsx
@@ -108,7 +108,7 @@ const KrakenOfTheSky = () => {
             <Content title="PROJECT REPORT">
               A complete report of this project, including descriptions of onboard and ground
               support systems, engineering drawings of all rocket components, and a complete
-              set of assembly and launch procedures for SotS can be downloaded&nbsp;
+              set of assembly and launch procedures for KotS can be downloaded&nbsp;
               <a href="https://www.waterloorocketry.com/pdfs/2022_project_report.pdf">here.</a>
             </Content>
           </>


### PR DESCRIPTION
KotS page had `SotS` instead of `KotS` in project report section

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/52)
<!-- Reviewable:end -->
