### PR TITLE
Fix cover photo heights

### DIFF
--- a/src/components/CoverPhoto/CoverPhoto.module.css
+++ b/src/components/CoverPhoto/CoverPhoto.module.css
@@ -2,4 +2,5 @@
   background-repeat: no-repeat;
   background-position: 50% 90%;
   background-size: cover;
+  height: 15rem;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 /* General */
 
 html, body, #root {
-	height: 100%;
+	min-height: 100vh;
 }
 
 #root{

--- a/src/routes/Awards.jsx
+++ b/src/routes/Awards.jsx
@@ -15,7 +15,7 @@ import TechnicalExcellenceImage from '../img/awards/technical_excellence.png';
 const Awards = () => {
   return (
     <>
-      <CoverPhoto image={awardsCoverImage} style={{ height: '35rem', backgroundPosition: '50% 40%' }} />
+      <CoverPhoto image={awardsCoverImage} style={{ backgroundPosition: '50% 40%' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-5 justify-content-right">
           <AwardYear Year={2023} />

--- a/src/routes/Competition.jsx
+++ b/src/routes/Competition.jsx
@@ -13,7 +13,7 @@ import SpaceportImage from '../img/competition/spaceport_group.jpg';
 const Competition = () => {
   return (
     <>
-      <CoverPhoto image={compCoverImage} style={{ height: '35rem', backgroundPosition: '50% 90%' }} />
+      <CoverPhoto image={compCoverImage} style={{ backgroundPosition: '50% 90%' }} />
       <Container fluid>
         <Row className="my-4 mx-0 gx-5 justify-content-left">
           <Col className="" lg={{ span: 6 }}>

--- a/src/routes/Contact.jsx
+++ b/src/routes/Contact.jsx
@@ -16,7 +16,7 @@ const Contact = () => {
     <>
       <CoverPhoto
         image={contactCoverPhoto}
-        style={{ height: '22rem', backgroundPosition: '50% 100%' }}
+        style={{ backgroundPosition: '50% 100%' }}
       />
       <Container fluid>
         <Row lg={2} md={2} sm={1} xs={1}>

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -15,7 +15,7 @@ import galleryCoverImage from '../img/home/link_to_gallery.jpg';
 const Home = () => {
   return (
     <>
-      <CoverPhoto image={coverPhotoImage} style={{ height: '39rem', backgroundPosition: '50% 60%' }} />
+      <CoverPhoto image={coverPhotoImage} style={{ backgroundPosition: '50% 60%' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-5 justify-content-center">
           <Col lg={{ span: 4 }}>

--- a/src/routes/Join.jsx
+++ b/src/routes/Join.jsx
@@ -14,7 +14,7 @@ import joinCoverPhoto from '../img/join/cover_join.jpg';
 const Join = () => {
   return (
     <>
-      <CoverPhoto image={joinCoverPhoto} style={{ height: '28rem', backgroundPosition: 'center bottom' }} />
+      <CoverPhoto image={joinCoverPhoto} style={{ backgroundPosition: 'center bottom' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-5 justify-content-center">
           <Content title="WHY JOIN US?">

--- a/src/routes/Outreach.jsx
+++ b/src/routes/Outreach.jsx
@@ -19,7 +19,7 @@ import edPhoto from '../img/outreach/ed_session.jpg';
 const Outreach = () => {
   return (
     <>
-      <CoverPhoto image={outreachCoverPhoto} style={{ height: '30rem', backgroundPosition: '50% 40%' }} />
+      <CoverPhoto image={outreachCoverPhoto} style={{ backgroundPosition: '50% 40%' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-5 justify-content-center">
           <Content title="OUTREACH">

--- a/src/routes/Sponsors.jsx
+++ b/src/routes/Sponsors.jsx
@@ -82,7 +82,7 @@ import waterlooEngMechanical from '../img/sponsorship/5_previous_sponsors/Waterl
 const Sponsors = () => {
   return (
     <>
-      <CoverPhoto image={sponsorCoverImage} style={{ height: '35rem', position: '50% 90%' }} />
+      <CoverPhoto image={sponsorCoverImage} style={{ position: '50% 90%' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-4 justify-content-center">
           <Col lg={{ span: 10 }}>

--- a/src/routes/Subsystems.jsx
+++ b/src/routes/Subsystems.jsx
@@ -38,7 +38,7 @@ const Subsystems = () => {
 
   return (
     <>
-      <CoverPhoto image={subsystemsCoverImage} style={{ height: '35rem', backgroundPosition: '50% 90%' }} />
+      <CoverPhoto image={subsystemsCoverImage} style={{ backgroundPosition: '50% 90%' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-5 justify-content-center">
           <Content title="SUBSYSTEMS">

--- a/src/routes/Team.jsx
+++ b/src/routes/Team.jsx
@@ -93,7 +93,7 @@ import styles from './css/Team.module.css';
 const Team = () => {
   return (
     <>
-      <CoverPhoto image={teamCoverImage} style={{ height: '35rem', position: 'center bottom' }} />
+      <CoverPhoto image={teamCoverImage} style={{ position: 'center bottom' }} />
       <Container fluid>
         <Row className="my-4 mx-2 gx-4 justify-content-center">
           <Col>


### PR DESCRIPTION
There is currently an issue with the site's cover photos where they are a lot shorter in height than they should be. It is likely that this stemmed from #45 somehow. 

This PR fixes this by replacing the `height: 100%` that we used to make the sticky footer work with `min-height: 100vh` and sets a consistent height of 15rem for all cover photos.

Before:
![Screenshot_20231113_155449](https://github.com/waterloo-rocketry/website-react/assets/8643561/d601f382-22f4-4dfe-ad49-420798dc55b6)


After:
![Screenshot_20231113_155354](https://github.com/waterloo-rocketry/website-react/assets/8643561/b007dd55-c545-4189-b890-9bc9cdf48591)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/53)
<!-- Reviewable:end -->
