### PR TITLE
Added Luca and Ben Canards reports

### DIFF
--- a/src/routes/Documentation.jsx
+++ b/src/routes/Documentation.jsx
@@ -113,6 +113,20 @@ const Documentation = () => {
             {/* eslint-disable max-len */}
             <ul className="competition-reports-link-list">
               <li>
+                Mechanical Design of Roll Control Canards - Ben Pickens (June 2025) |
+                <a href="https://drive.google.com/file/d/1k6xjEufHSWInonTrrOUHfPoZFRcp5GzU/preview" target="_blank" rel="noreferrer">View</a>
+                {' '}
+                |
+                <a href="https://drive.google.com/uc?export=download&id=1k6xjEufHSWInonTrrOUHfPoZFRcp5GzU" download>Download</a>
+              </li>
+              <li>
+                Canards Aerodynamic Design for an Active Roll-Control System - Luca Scavone (March 2025) |
+                <a href="https://drive.google.com/file/d/174mq2jf7EHIr_QtrmcfE5dtUbLe7okBr/preview" target="_blank" rel="noreferrer">View</a>
+                {' '}
+                |
+                <a href="https://drive.google.com/uc?export=download&id=174mq2jf7EHIr_QtrmcfE5dtUbLe7okBr" download>Download</a>
+              </li>
+              <li>
                 Increasing Rocket Apogee by 23% Through Iterative Design - Joel Godard (Jan 2024) |
                 <a href="https://drive.google.com/file/d/1WCfqrq5eObcD8L7Ti5hjObDkq3xk2J32/preview" target="_blank" rel="noreferrer">View</a>
                 {' '}


### PR DESCRIPTION
## Description
<!-- Add background/context for the PR (why are we making these changes?) and a description of the changes that this makes. -->
- Uploaded Ben and Luca documents to Google Drive https://drive.google.com/drive/folders/1dML0nkfUa1q2rV4jj6eaAQ5zHLeRa80U
- Linked on Documentation page, under Work-Term Reports

<!-- Replace "00" with the relevant GitHub issue number. -->
<!-- e.g. https://github.com/waterloo-rocketry/website-react/issues/44 has issue #44 -->
This PR closes #106 .

Verify that the documents appear appropriately on the Documentation page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website-react/107)
<!-- Reviewable:end -->
