### PR TITLE
fix: Hotfix HyperLink and Description, adjust height of some sponsor image

### DIFF
--- a/src/components/SponsorLinkWithDesc/SponsorLinkWithDesc.jsx
+++ b/src/components/SponsorLinkWithDesc/SponsorLinkWithDesc.jsx
@@ -4,7 +4,7 @@ import { Image } from 'react-bootstrap';
 import styles from './SponsorLinkWithDesc.module.css';
 
 const SponsorLinkWithDesc = ({
-  image, link, children, logoTier,
+  image, link, children, logoTier, zoom = 1,
 }) => {
   let [imageStyle, containerStyle] = [styles.imgPrevious, styles.logoContainer];
 
@@ -18,10 +18,12 @@ const SponsorLinkWithDesc = ({
     [imageStyle, containerStyle] = [styles.imgBronze, styles.logoContainer];
   }
 
+  const imageZoomStyle = { transform: `scale(${zoom})` };
+
   return (
     <div className={containerStyle}>
       <a href={link} rel="noreferrer" target="_blank">
-        <Image className={imageStyle} src={image} />
+        <Image className={imageStyle} src={image} style={imageZoomStyle} />
       </a>
       {
         (logoTier === 'platinum' || logoTier === 'gold') && <p className={styles.imageLinkText}>{children}</p>

--- a/src/routes/Sponsors.jsx
+++ b/src/routes/Sponsors.jsx
@@ -238,8 +238,19 @@ const Sponsors = () => {
 
           <Row className="my-4 mx-2 gx-4 justify-content-center text-center">
             <Col lg={{ span: 5 }}>
-              <SponsorLinkWithDesc logoTier="platinum" image={msam} link="https://msam-uwaterloo.ca" />
-              <p />
+              <SponsorLinkWithDesc logoTier="platinum" image={msam} link="https://msam.uwaterloo.ca/" />
+              <p>
+                The Multiscale Additive Manufacturing (MSAM) Lab at the
+                University of Waterloo is one of Canada&apos;s largest research
+                facilities dedicated to metal additive manufacturing. Combining
+                world-class expertise in materials science, mechanical
+                engineering, and computational modeling, MSAM leads cutting-edge
+                research to advance 3D printing technologies for industrial
+                applications. Collaborating with industry leaders across
+                aerospace, automotive, energy, and healthcare sectors, MSAM is
+                driving innovation in design, process optimization, and
+                performance of additively manufactured components.
+              </p>
             </Col>
             <Col lg={{ span: 5 }}>
               <SponsorLinkWithDesc logoTier="platinum" image={solidworks} link="https://www.solidworks.com/">
@@ -330,8 +341,18 @@ const Sponsors = () => {
 
           <Row className="my-4 mx-2 gx-4 justify-content-center text-center">
             <Col lg={{ span: 5 }}>
-              <SponsorLinkWithDesc logoTier="platinum" image={novatel} link="https://www.novatel.com/">
-                <p />
+              <SponsorLinkWithDesc logoTier="platinum" image={novatel} zoom={1.4} link="https://www.novatel.com/">
+                <p>
+                  NovAtel is a global leader in precise positioning technology,
+                  delivering high-performance GNSS solutions that power everything
+                  from autonomous vehicles to precision agriculture and defense
+                  applications. With a deep focus on innovation, NovAtel designs
+                  and manufactures advanced satellite navigation systems that
+                  ensure accuracy, reliability, and integrity. Backed by a team of
+                  engineers and researchers, NovAtel continues to set the standard
+                  in positioning excellence—enabling smarter, safer, and more
+                  efficient systems worldwide.
+                </p>
               </SponsorLinkWithDesc>
             </Col>
           </Row>
@@ -379,7 +400,7 @@ const Sponsors = () => {
               </SponsorLinkWithDesc>
             </Col>
             <Col lg={{ span: 5 }}>
-              <SponsorLinkWithDesc logoTier="gold" image={harwin} link="https://www.harwin.com/">
+              <SponsorLinkWithDesc logoTier="gold" image={harwin} zoom={0.5} link="https://www.harwin.com/">
                 <p className="content-text">
                   Since 1952, the de Laszlo family has led Harwin, evolving from a turning facility
                   to a global leader in interconnects. Through innovation, advanced technologies,
@@ -404,7 +425,17 @@ const Sponsors = () => {
             </Col>
             <Col lg={{ span: 5 }}>
               <SponsorLinkWithDesc logoTier="gold" image={moderncrane} link="https://moderncrane.ca/" />
-              <p />
+              <p>
+                Modern Crane is a trusted provider of crane rental and heavy
+                lifting services across Ontario, known for its commitment to
+                safety, reliability, and expert service. With a modern fleet and
+                experienced operators, Modern Crane supports a wide range of
+                industries including construction, infrastructure, and energy.
+                Whether it&apos;s mobile crane rentals, hoisting solutions, or
+                project planning support, Modern Crane delivers efficient and
+                dependable lifting services tailored to meet the unique needs of
+                every job.
+              </p>
             </Col>
           </Row>
 
@@ -444,7 +475,7 @@ const Sponsors = () => {
               <SponsorLinkWithDesc logoTier="silver" image={mitutoyo} link="https://www.mitutoyo.ca/" />
             </Col>
             <Col md="auto">
-              <SponsorLinkWithDesc logoTier="silver" image={samcomachinery} link="https://samco-machinery.com/" />
+              <SponsorLinkWithDesc logoTier="silver" image={samcomachinery} zoom={1.5} link="https://samco-machinery.com/" />
             </Col>
             <Col md="auto">
               <SponsorLinkWithDesc logoTier="silver" image={engsoc} link="https://www.engsoc.uwaterloo.ca/" />
@@ -473,7 +504,7 @@ const Sponsors = () => {
               <SponsorLinkWithDesc logoTier="bronze" image={customClothes} link="https://customclothes.ca/" />
             </Col>
             <Col md="auto">
-              <SponsorLinkWithDesc logoTier="bronze" image={tplink} link="https://www.tp-link.com/ca/" />
+              <SponsorLinkWithDesc logoTier="bronze" image={tplink} zoom={1.4} link="https://www.tp-link.com/ca/" />
             </Col>
             <Col md="auto">
               <SponsorLinkWithDesc logoTier="bronze" image={designelectronics} link="https://www.designelectronics.net/" />


### PR DESCRIPTION
This pull request introduces enhancements to the `SponsorLinkWithDesc` component and updates the `Sponsors` page to improve sponsor presentation. The main changes include adding a `zoom` prop to control image scaling, updating sponsor descriptions with detailed text, and refining sponsor links.

### Component Enhancements:
* [`src/components/SponsorLinkWithDesc/SponsorLinkWithDesc.jsx`](diffhunk://#diff-de2b352e28d8821982f25a4fcfd91f4223a4cbd05ebaee0e98d6e946d9bdcb84L7-R7): Added a `zoom` prop to the `SponsorLinkWithDesc` component, allowing customization of the image scaling via a `transform: scale()` style. This provides flexibility in displaying sponsor logos at different sizes. [[1]](diffhunk://#diff-de2b352e28d8821982f25a4fcfd91f4223a4cbd05ebaee0e98d6e946d9bdcb84L7-R7) [[2]](diffhunk://#diff-de2b352e28d8821982f25a4fcfd91f4223a4cbd05ebaee0e98d6e946d9bdcb84R21-R26)

### Sponsor Page Updates:
* [`src/routes/Sponsors.jsx`](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L241-R253): Updated sponsor entries to include detailed descriptions for several sponsors, enhancing the page's informational value. Examples include MSAM, NovAtel, Modern Crane, and others. [[1]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L241-R253) [[2]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L333-R355) [[3]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L407-R438)
* [`src/routes/Sponsors.jsx`](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L333-R355): Applied the new `zoom` prop to specific sponsors to adjust logo sizes for better visual balance. For instance, NovAtel (`zoom={1.4}`), Harwin (`zoom={0.5}`), Samco Machinery (`zoom={1.5}`), and TP-Link (`zoom={1.4}`). [[1]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L333-R355) [[2]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L382-R403) [[3]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L447-R478) [[4]](diffhunk://#diff-2dc1fd72f506ef9581205e1bb2c2feffd2623a589c0e7a6bf970882beca224a1L476-R507)